### PR TITLE
Docker File fix (pip version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ADD . /app
 
 WORKDIR /app
 
-RUN easy_install pip==20.2.4
+# TODO remove in the frame of D3ASIM-3093:
+RUN pip install -U pip==20.2.4
+
 RUN pip install -e .
 
 ENTRYPOINT ["python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /app
 
 WORKDIR /app
 
-RUN pip install --upgrade pip
+RUN easy_install pip==20.2.4
 RUN pip install -e .
 
 ENTRYPOINT ["python"]

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,8 @@ deps =
 commands =
 	python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
     pip-sync requirements/base.txt
+	# TODO remove in the frame of D3ASIM-3093:
+	pip install -U pip==20.2.4
     pip install -e .
     py.test unit_tests
     behave integration_tests


### PR DESCRIPTION
Updating the docker file to match the correct pip version for successfully buildling docker image to run d3a_api_client inside docker container.