### PR TITLE
feature/D3ASIM-3066:change set_power_forecast to set_energy_forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The energy consumption or demand for PV and Load devices can be set for the next
 the following command 
 (assuming that a [connection to a device was established](#how-to-create-a-connection-to-a-device)):
 ```
-device_client.set_energy_forecast(<pv_energy_forecast_W>)
+device_client.set_energy_forecast(<pv_energy_forecast_Wh>)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The energy consumption or demand for PV and Load devices can be set for the next
 the following command 
 (assuming that a [connection to a device was established](#how-to-create-a-connection-to-a-device)):
 ```
-device_client.set_power_forecast(<power_power_forecast_W>)
+device_client.set_energy_forecast(<pv_energy_forecast_W>)
 ```
 
 ---

--- a/d3a_api_client/rest_device.py
+++ b/d3a_api_client/rest_device.py
@@ -76,12 +76,12 @@ class RestDeviceClient(APIClientInterface, RestCommunicationMixin):
                                           "device_uuid": self.device_id}, self.jwt_token)
         self.active_aggregator = None
 
-    @logging_decorator('set_power_forecast')
-    def set_power_forecast(self, pv_power_forecast_W, do_not_wait=False):
-        transaction_id, posted = self._post_request('set_power_forecast',
-                                                    {"power_forecast": pv_power_forecast_W})
+    @logging_decorator('set_energy_forecast')
+    def set_energy_forecast(self, pv_energy_forecast_Wh, do_not_wait=False):
+        transaction_id, posted = self._post_request('set_energy_forecast',
+                                                    {"energy_forecast": pv_energy_forecast_Wh})
         if posted and do_not_wait is False:
-            return self.dispatcher.wait_for_command_response('set_power_forecast', transaction_id)
+            return self.dispatcher.wait_for_command_response('set_energy_forecast', transaction_id)
 
     @logging_decorator('offer')
     def offer_energy(self, energy, price):

--- a/integration_tests/steps/market.py
+++ b/integration_tests/steps/market.py
@@ -20,7 +20,7 @@ def step_impl(context):
         try:
             last_market_stats = context.device.last_market_stats()
             assert list(last_market_stats.keys()) == \
-                   ['status', 'area_uuid', 'command', 'market_stats', 'transaction_id']
+                   ['status', 'name', 'area_uuid', 'command', 'market_stats', 'transaction_id']
             sleep(2)
             time_out += 2
         except AssertionError as e:

--- a/integration_tests/test_grid_fee.py
+++ b/integration_tests/test_grid_fee.py
@@ -36,7 +36,7 @@ class AutoGridFeeUpdateOnMarket(RedisMarketClient):
             assert float(self.updated_fee["market_fee_const"]) == expected_grid_fee
             self.list_dso_stats = self.last_market_dso_stats()
             assert set(self.list_dso_stats.keys()) == \
-                   {'status', 'transaction_id', 'market_stats', 'command', 'area_uuid'}
+                   {'transaction_id', 'market_stats', 'area_uuid', 'name', 'command', 'status'}
 
         except AssertionError as e:
             logging.error(f"Raised exception: {e}. Traceback: {traceback.format_exc()}")

--- a/mqtt_subscriber/oli_broker.py
+++ b/mqtt_subscriber/oli_broker.py
@@ -45,14 +45,13 @@ class MQTTConnection:
             payload = json.loads(msg.payload.decode("utf-8"))
 
             energy = payload["value"]
-            power = energy * (MINUTES_IN_HOUR / MEASUREMENT_PERIOD_MINUTES)
 
             # Transmit power values to CN
             for api_args in self.topic_api_client_dict[msg.topic]:
-                RestDeviceClient(**api_args).set_power_forecast(power, do_not_wait=True)
+                RestDeviceClient(**api_args).set_energy_forecast(energy, do_not_wait=True)
 
         except Exception as e:
-            logging.error(f"API Client failed to send power forecasts to d3a with error {e}. "
+            logging.error(f"API Client failed to send energy forecasts to d3a with error {e}. "
                           f"Resuming operation.")
             logging.error(f"{traceback.format_exc()}")
 

--- a/tests/test_sending_power_forecast.py
+++ b/tests/test_sending_power_forecast.py
@@ -21,12 +21,12 @@ class AutoSendForecast(RestDeviceClient):
         root_logger.debug(f"New market information {market_info}")
         self.forecast += 50
         if "available_energy_kWh" in market_info["device_info"]:
-            root_logger.info(f"self.set_pv_power_forecast({self.forecast})")
-            response = self.set_power_forecast(self.forecast)
+            root_logger.info(f"self.set_pv_energy_forecast({self.forecast})")
+            response = self.set_energy_forecast(self.forecast)
 
         if "energy_requirement_kWh" in market_info["device_info"]:
-            root_logger.info(f"self.set_load_power_forecast({self.forecast})")
-            response = self.set_power_forecast(self.forecast)
+            root_logger.info(f"self.set_load_energy_forecast({self.forecast})")
+            response = self.set_energy_forecast(self.forecast)
 
     def on_tick(self, tick_info):
         logging.debug(f"Progress information on the device: {tick_info}")


### PR DESCRIPTION
[Ticket](https://gridsingularity.atlassian.net/browse/D3ASIM-3066)
### Description
Changed `set_power_forecast` functions / endpoints to `set_energy_forecast` in `Oli_broker` and `api-client`

## Note
This is a sub PR related to D3A [Parent PR](https://github.com/gridsingularity/d3a/pull/1007)