### PR TITLE
feature/D3ASIM-3214: Added on_event_or_response callback

### DIFF
--- a/d3a_api_client/__init__.py
+++ b/d3a_api_client/__init__.py
@@ -142,6 +142,17 @@ class APIClientInterface(ABC):
         """
         pass
 
+    def on_event_or_response(self, message):
+        """
+       Method that is meant to be overridden, to allow custom user actions when any event or response is
+        received by the client.
+       A user of the class should be able to override this method via subclassing. This method will
+       be called in the background when an event or response is received.
+       :param message: Information about the event or response that was reported
+       :return: None
+        """
+        pass
+
     def on_market_cycle(self, market_info):
         """
         Method that is meant to be overridden, to allow custom user actions when a new market is

--- a/d3a_api_client/redis_aggregator.py
+++ b/d3a_api_client/redis_aggregator.py
@@ -84,6 +84,8 @@ class RedisAggregator:
         elif "event" in payload and payload["event"] == "finish":
             self._on_finish(payload)
 
+        self.on_event_or_response(payload)
+
     def _check_transaction_id_cached_out(self, transaction_id):
         return transaction_id in self._transaction_id_buffer
 

--- a/d3a_api_client/redis_aggregator.py
+++ b/d3a_api_client/redis_aggregator.py
@@ -205,3 +205,6 @@ class RedisAggregator:
 
     def on_batch_response(self, message):
         pass
+
+    def on_event_or_response(self, message):
+        pass

--- a/d3a_api_client/redis_client_base.py
+++ b/d3a_api_client/redis_client_base.py
@@ -301,3 +301,6 @@ class RedisClient(APIClientInterface):
 
     def on_finish(self, finish_info):
         pass
+
+    def on_event_or_response(self, message):
+        pass

--- a/d3a_api_client/redis_device.py
+++ b/d3a_api_client/redis_device.py
@@ -41,8 +41,8 @@ class RedisDeviceClient(RedisClient):
         channel_subs[f'{self._channel_prefix}/events/trade'] = self._on_trade
         channel_subs[f'{self._channel_prefix}/events/finish'] = self._on_finish
         channel_subs["aggregator_response"] = self._aggregator_response_callback
-
-        self.pubsub.subscribe(**channel_subs)
+        channel_subs[f'{self._channel_prefix}/*'] = self._on_event_or_response
+        self.pubsub.psubscribe(**channel_subs)
         if pubsub_thread is None:
             self.pubsub.run_in_thread(daemon=True)
 

--- a/d3a_api_client/redis_market.py
+++ b/d3a_api_client/redis_market.py
@@ -203,3 +203,6 @@ class RedisMarketClient:
 
     def on_finish(self, finish_info):
         pass
+
+    def on_event_or_response(self, message):
+        pass

--- a/d3a_api_client/rest_market.py
+++ b/d3a_api_client/rest_market.py
@@ -76,3 +76,6 @@ class RestMarketClient(RestCommunicationMixin):
 
     def on_market_cycle(self, market_info):
         pass
+
+    def on_event_or_response(self, message):
+        pass

--- a/d3a_api_client/websocket_device.py
+++ b/d3a_api_client/websocket_device.py
@@ -30,7 +30,7 @@ class WebsocketMessageReceiver:
         elif "command" in message:
             self.command_response_buffer.append(message)
 
-        if "event" in message.keys() or "command" in message.keys():
+        if "event" in message or "command" in message:
             self.client.on_event_or_response(message)
 
     def wait_for_command_response(self, command_name, transaction_id, timeout=120):

--- a/d3a_api_client/websocket_device.py
+++ b/d3a_api_client/websocket_device.py
@@ -30,6 +30,9 @@ class WebsocketMessageReceiver:
         elif "command" in message:
             self.command_response_buffer.append(message)
 
+        if "event" in message.keys() or "command" in message.keys():
+            self.client.on_event_or_response(message)
+
     def wait_for_command_response(self, command_name, transaction_id, timeout=120):
         def check_if_command_response_received():
             return any("command" in c and c["command"] == command_name and

--- a/integration_tests/device.feature
+++ b/integration_tests/device.feature
@@ -14,6 +14,7 @@ Scenario: API client can connect successfully to a PV device and perform all ope
    When the external client is started with test_pv_connection
    Then the external client is connecting to the simulation until finished
    And the external client does not report errors
+   And the on_event_or_response is called for different events
 
 Scenario: External ESS agent not allowed to overcharge the Storage State
    Given redis container is started

--- a/integration_tests/steps/device.py
+++ b/integration_tests/steps/device.py
@@ -42,6 +42,18 @@ def step_impl(context):
                                          redis_url='redis://localhost:6379/')
 
 
+@then('the on_event_or_response is called for different events')
+def step_impl(context):
+    # Check if the market event triggered both the on_market_cycle and on_event_or_response
+    print(context.device.events)
+    assert context.device.events == {'event', 'command',
+                                     'tick', 'register',
+                                     'offer_delete', 'trade',
+                                     'offer', 'unregister',
+                                     'list_offers', 'market'}
+    assert context.device.is_on_market_cycle_called
+
+
 @when('the external client is started with test_ess_bid_connection')
 def step_impl(context):
     # Wait for d3a to activate all areas

--- a/integration_tests/steps/device.py
+++ b/integration_tests/steps/device.py
@@ -45,7 +45,6 @@ def step_impl(context):
 @then('the on_event_or_response is called for different events')
 def step_impl(context):
     # Check if the market event triggered both the on_market_cycle and on_event_or_response
-    print(context.device.events)
     assert context.device.events == {'event', 'command',
                                      'tick', 'register',
                                      'offer_delete', 'trade',

--- a/integration_tests/test_pv_connection.py
+++ b/integration_tests/test_pv_connection.py
@@ -15,9 +15,12 @@ class AutoOfferOnPVDevice(RedisDeviceClient):
         self.latest_stats = {}
         self.market_info = {}
         self.device_bills = {}
+        self.is_on_market_cycle_called = False
+        self.events = set()
         super().__init__(*args, **kwargs)
 
     def on_market_cycle(self, market_info):
+        self.is_on_market_cycle_called = True
         try:
             assert "available_energy_kWh" in market_info["device_info"]
             available_energy = market_info["device_info"]["available_energy_kWh"]
@@ -66,3 +69,10 @@ class AutoOfferOnPVDevice(RedisDeviceClient):
             self.error_list.append(e)
             raise e
 
+    def on_event_or_response(self, message):
+        if "command" in message.keys():
+            self.events.add("command")
+            self.events.add(message["command"])
+        if "event" in message.keys():
+            self.events.add("event")
+            self.events.add(message["event"])


### PR DESCRIPTION
## Implementation details:
Added a new callback function `on_event_or_response` to all Rest and Redis api devices.
This callback will be triggered upon receiving any message through the `Web socket` in the rest case or response received in a subscribed channel in the redis case.
Added an integration test to test if the current callback methods are also called + if the new callback is receiving all messages.