### PR TITLE
refactor_trading_script: Changing the data type of arguments

### DIFF
--- a/d3a_api_client/setups/e2e_test_auto_offer_on_device_rest.py
+++ b/d3a_api_client/setups/e2e_test_auto_offer_on_device_rest.py
@@ -15,8 +15,8 @@ parser.add_argument("--simulation_id", type=str, help="Simulation uuid", require
 parser.add_argument("--load_names", nargs='+', default=[])
 parser.add_argument("--pv_names", nargs='+', default=[])
 parser.add_argument("--storage_names", nargs='+', default=[])
-parser.add_argument("--domain_name", nargs='+', default=[])
-parser.add_argument("--websockets_domain_name", nargs='+', default=[])
+parser.add_argument("--domain_name", type=str, help="domain_name", required=True)
+parser.add_argument("--websockets_domain_name", type=str, help="websocket_name", required=True)
 
 args = parser.parse_args()
 connected_devices = []


### PR DESCRIPTION
Changing the data type of arguments : domain_name and websockets_domain_name. Earlier there data type was list now converting them into string.