### PR TITLE
D3ASIM-3325: Added small fixes.

### DIFF
--- a/d3a_api_client/rest_device.py
+++ b/d3a_api_client/rest_device.py
@@ -29,7 +29,7 @@ class RestDeviceClient(APIClientInterface, RestCommunicationMixin):
         self.websockets_domain_name = websockets_domain_name
         self.aggregator_prefix = get_aggregator_prefix(domain_name, simulation_id)
         self.active_aggregator = None
-        if start_websocket:
+        if start_websocket or autoregister:
             self.start_websocket_connection()
 
         self.registered = False

--- a/d3a_api_client/utils.py
+++ b/d3a_api_client/utils.py
@@ -93,7 +93,7 @@ def request_response_returns_http_2xx(endpoint, resp):
         return True
     else:
         logging.error(f"Request to {endpoint} failed with status code {resp.status_code}. "
-                     f"Response body: {json.loads(resp.text).get('error')}")
+                      f"Response body: {resp.text}")
         return False
 
 


### PR DESCRIPTION
Two small fixed:
1. if autoregister is set to True in the RestClient, the wesocket should be established in order to receive the response of the d3a.
2. When there is a http response, there `resp.text` is not a dict, but only a string.