### PR TITLE
D3ASIM-3379: Deprecate old batch commands

### DIFF
--- a/d3a_api_client/aggregator.py
+++ b/d3a_api_client/aggregator.py
@@ -112,14 +112,6 @@ class Aggregator(RestDeviceClient):
         """
         return self._client_command_buffer
 
-    def batch_command(self, batch_command_dict):
-        # TODO: Remove this as this is kept atm for the backward compatibility
-        self._all_uuids_in_selected_device_uuid_list(batch_command_dict.keys())
-        transaction_id, posted = self._post_request(
-            'batch-commands', {"aggregator_uuid": self.aggregator_uuid, "batch_commands": batch_command_dict})
-        if posted:
-            return self.dispatcher.wait_for_command_response('batch_commands', transaction_id)
-
     @property
     def commands_buffer_length(self):
         """

--- a/d3a_api_client/redis_aggregator.py
+++ b/d3a_api_client/redis_aggregator.py
@@ -161,26 +161,6 @@ class RedisAggregator:
         """
         return self._client_command_buffer.buffer_length
 
-    def batch_command(self, batch_command_dict, is_blocking=True):
-        # TODO: Remove this as this is kept atm for the backward compatibility
-        self._all_uuids_in_selected_device_uuid_list(batch_command_dict.keys())
-        transaction_id = str(uuid.uuid4())
-        batched_command = {"type": "BATCHED", "transaction_id": transaction_id,
-                           "aggregator_uuid": self.aggregator_uuid,
-                           "batch_commands": batch_command_dict}
-        batch_channel = f'external//aggregator/{self.aggregator_uuid}/batch_commands'
-        self.redis_db.publish(batch_channel, json.dumps(batched_command))
-        self._transaction_id_buffer.append(transaction_id)
-
-        if is_blocking:
-            try:
-                wait_until_timeout_blocking(
-                    lambda: not self._check_transaction_id_cached_out(transaction_id)
-                )
-                return self._transaction_id_response_buffer.get(transaction_id, None)
-            except AssertionError:
-                raise RedisAPIException(f'API registration process timed out.')
-
     def execute_batch_commands(self, is_blocking=True):
         if not self.commands_buffer_length:
             return


### PR DESCRIPTION
## Note
This is to be merged alongside #109 , #114 and other client PRs as they require adaptation from the used client scripts